### PR TITLE
Fix updating DATA_DIR to current setting when loading checkpoint

### DIFF
--- a/procyon/model/model_unified.py
+++ b/procyon/model/model_unified.py
@@ -1323,6 +1323,7 @@ class UnifiedProCyon(nn.Module):
                 - Set enforce_checkpoint_architecture_strict=True if you want to assert that architecture arguments align
         '''
         config_checkpoint = torch.load(os.path.join(checkpoint_dir, "model_args.pt"))
+        data_args = torch.load(os.path.join(checkpoint_dir, "data_args.pt"))
 
         if config is None:
             config = config_checkpoint
@@ -1368,7 +1369,7 @@ class UnifiedProCyon(nn.Module):
             config.protein_pooling_correction_option = protein_pooling_correction_option
 
         if model is None:
-            update_model_args_data_dir(config)
+            update_model_args_data_dir(config, prev_data_dir=data_args.data_dir)
             model = UnifiedProCyon(pretrained_weights_dir = pretrained_weights_dir, config = config, for_pretraining = False)
 
             # Check if state_dict has been consolidated locally:

--- a/procyon/training/training_args_IT.py
+++ b/procyon/training/training_args_IT.py
@@ -1784,14 +1784,10 @@ def get_hparams(args_tuple: Tuple[dataclass]):
 
     return hparams
 
-def update_model_args_data_dir(model_args: ModelArgs):
+def update_model_args_data_dir(model_args: ModelArgs, prev_data_dir: str):
     if not isinstance(model_args, ModelArgs):
         raise ValueError(f"expected ModelArgs, got: {type(model_args)}")
 
-    # Just arbitrarily picked one argument to use to try to get the DATA_DIR used for
-    # the current set of model arguments.
-    arg_suffix = ModelArgs().protein_seq_embeddings_path.lstrip(DATA_DIR)
-    prev_data_dir = model_args.protein_seq_embeddings_path.rstrip(arg_suffix)
     if DATA_DIR == prev_data_dir:
         return
     print(f"updating model args DATA_DIR from {prev_data_dir} -> {DATA_DIR}")


### PR DESCRIPTION
When loading a pretrained checkpoint, the serialized `ModelArgs` contain paths that use the `DATA_DIR` setting as it was when the model was trained. We need to update these to the current setting for the user loading the model.

The previous code for doing this updating was flawed, but happened to work in a few specific settings. This change switches to a more robust method of updating the data directory.