### PR TITLE
Fix pyproject after API PR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,16 +51,19 @@ dependencies = [
    "virtualenv==20.28.0",
    "wandb==0.16.3",
    "bert-score>=0.3.13",
-   "argparse>=1.4.0",
-   "huggingface-hub==0.23.4",
-   "fastapi>=0.109.0",
-   "uvicorn>=0.27.0",
    "scanpy>=1.10.4",
+]
 
 
 [project.optional-dependencies]
 build = ["torch", "setuptools", "packaging"]
 compile = ["flash-attn"]
+api = [
+   "argparse>=1.4.0",
+   "huggingface-hub==0.23.4",
+   "fastapi>=0.109.0",
+   "uvicorn>=0.27.0",
+]
 
 [tool.uv]
 no-build-isolation-package = ["flash-attn"]


### PR DESCRIPTION
Fix missing bracket in `pyproject.toml` after merging in #7 (seemed easiest since PR was coming from a now read-only fork). Also move API-specific dependencies to a separate, optional dependency group (`api`)